### PR TITLE
Empty ByteBufferList unhandled exception.

### DIFF
--- a/ion/src/com/koushikdutta/ion/LoadBitmap.java
+++ b/ion/src/com/koushikdutta/ion/LoadBitmap.java
@@ -31,8 +31,13 @@ class LoadBitmap extends BitmapCallback implements FutureCallback<ByteBufferList
         ion.getServer().getExecutorService().execute(new Runnable() {
             @Override
             public void run() {
-                ByteBuffer bb = result.getAll();
+                ByteBuffer bb = null;
                 try {
+                	if (result.size() == 0)
+                		throw new Exception("Bitmap failed to download");
+
+                	bb = result.getAll();
+                	
                     Bitmap bitmap = ion.bitmapCache.loadBitmap(bb.array(), bb.arrayOffset() + bb.position(), bb.remaining(), resizeWidth, resizeHeight);
 
                     if (bitmap == null)
@@ -48,7 +53,8 @@ class LoadBitmap extends BitmapCallback implements FutureCallback<ByteBufferList
                     report(e, null);
                 }
                 finally {
-                    ByteBufferList.reclaim(bb);
+                	if (bb != null)
+                		ByteBufferList.reclaim(bb);
                 }
             }
         });


### PR DESCRIPTION
If the ByteBufferList is empty getAll throws a NoSuchElementException. This can be handled at a lower level, but up here essentially the bitmap simply failed to download.
