### PR TITLE
fixed minor bug in GSON example

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ public static class Tweet {
 
 public void getTweets() throws Exception {
     Ion.with(context, "http://example.com/api/tweets")
-    .as(new TypeToken<List<Tweet>>(){});
+    .as(new TypeToken<List<Tweet>>(){})
     .setCallback(new FutureCallback<List<Tweet>>() {
        @Override
         public void onCompleted(Exception e, List<Tweet> tweets) {


### PR DESCRIPTION
This was causing an IDE error on cut/paste because the statement is prematurely ended with a semi-colon
