### PR TITLE
fix for the bad translation of pictures

### DIFF
--- a/ion/src/com/koushikdutta/ion/DefaultTransform.java
+++ b/ion/src/com/koushikdutta/ion/DefaultTransform.java
@@ -36,8 +36,8 @@ class DefaultTransform implements Transform {
 
             float postWidth = b.getWidth() * ratio;
             float postHeight = b.getHeight() * ratio;
-            float transx = (resizeWidth - postWidth) / 2;
-            float transy = (resizeHeight - postHeight) / 2;
+            float transx = (resizeWidth - postWidth) / (2*ratio);
+            float transy = (resizeHeight - postHeight) / (2*ratio);
             destination.set(transx, transy, transx + postWidth, transy + postHeight);
         }
 


### PR DESCRIPTION
When resizing a 495_500 picture into a 1080_1845 imageView ( scale center_crop), the imageView was translated too much to the left. I think this should fix the issue of these weird translations.
