### PR TITLE
Fix getInstrinsic{Width,Height} when using resources

### DIFF
--- a/ion/src/com/koushikdutta/ion/IonDrawable.java
+++ b/ion/src/com/koushikdutta/ion/IonDrawable.java
@@ -197,10 +197,22 @@ class IonDrawable extends Drawable {
             return info.bitmaps[0].getScaledWidth(resources.getDisplayMetrics().densityDpi);
         if (resizeWidth > 0)
             return resizeWidth;
-        if (error != null)
-            return error.getIntrinsicWidth();
-        if (placeholder != null)
+        if (info != null) {
+            if (error != null) {
+                return error.getIntrinsicWidth();
+            } else if (errorResource != 0) {
+                Drawable d = resources.getDrawable(errorResource);
+                assert d != null;
+                return d.getIntrinsicWidth();
+            }
+        }
+        if (placeholder != null) {
             return placeholder.getIntrinsicWidth();
+        } else if (placeholderResource != 0) {
+            Drawable d = resources.getDrawable(placeholderResource);
+            assert d != null;
+            return d.getIntrinsicWidth();
+        }
         return -1;
     }
 
@@ -210,10 +222,22 @@ class IonDrawable extends Drawable {
             return info.bitmaps[0].getScaledHeight(resources.getDisplayMetrics().densityDpi);
         if (resizeHeight > 0)
             return resizeHeight;
-        if (error != null)
-            return error.getIntrinsicHeight();
-        if (placeholder != null)
+        if (info != null) {
+            if (error != null) {
+                return error.getIntrinsicHeight();
+            } else if (errorResource != 0) {
+                Drawable d = resources.getDrawable(errorResource);
+                assert d != null;
+                return d.getIntrinsicHeight();
+            }
+        }
+        if (placeholder != null) {
             return placeholder.getIntrinsicHeight();
+        } else if (placeholderResource != 0) {
+            Drawable d = resources.getDrawable(placeholderResource);
+            assert d != null;
+            return d.getIntrinsicHeight();
+        }
         return -1;
     }
 


### PR DESCRIPTION
Also make sure we only use the error/errorResource width/height when an error has occurred.
