### PR TITLE
fix a crash when resizing with a dimension to 0 (based on the ImageView dimensions)

### DIFF
--- a/ion/src/com/koushikdutta/ion/IonImageViewRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonImageViewRequestBuilder.java
@@ -107,6 +107,8 @@ public class IonImageViewRequestBuilder extends IonBitmapRequestBuilder implemen
             return FUTURE_IMAGEVIEW_NULL_URI;
         }
 
+        withImageView(imageView);
+
         // executeCache the request, see if we get a bitmap from cache.
         BitmapFetcher bitmapFetcher = executeCache();
         if (bitmapFetcher.info != null) {


### PR DESCRIPTION
If some width or height are not set it tries to get them from the ImageView, but in this case it's missing the ImageView reference.
