### PR TITLE
do not force the size the placeholder and error drawables

### DIFF
--- a/ion/src/com/koushikdutta/ion/IonDrawable.java
+++ b/ion/src/com/koushikdutta/ion/IonDrawable.java
@@ -336,20 +336,19 @@ class IonDrawable extends Drawable {
                 return info.originalSize.x;
             if (info.bitmaps != null)
                 return info.bitmaps[0].getScaledWidth(resources.getDisplayMetrics().densityDpi);
+            // no image, but there was an error
+            Drawable error = tryGetErrorResource();
+            if (error != null)
+                return error.getIntrinsicWidth();
+        } else {
+            // check placeholder
+            Drawable placeholder = tryGetPlaceholderResource();
+            if (placeholder != null)
+                return placeholder.getIntrinsicWidth();
         }
         // check eventual image size...
         if (resizeWidth > 0)
             return resizeWidth;
-        // no image, but there was an error
-        if (info != null) {
-            Drawable error = tryGetErrorResource();
-            if (error != null)
-                return error.getIntrinsicWidth();
-        }
-        // check placeholder
-        Drawable placeholder = tryGetPlaceholderResource();
-        if (placeholder != null)
-            return placeholder.getIntrinsicWidth();
         // we're SOL
         return -1;
     }
@@ -361,17 +360,16 @@ class IonDrawable extends Drawable {
                 return info.originalSize.y;
             if (info.bitmaps != null)
                 return info.bitmaps[0].getScaledHeight(resources.getDisplayMetrics().densityDpi);
-        }
-        if (resizeHeight > 0)
-            return resizeHeight;
-        if (info != null) {
             Drawable error = tryGetErrorResource();
             if (error != null)
                 return error.getIntrinsicHeight();
+        } else {
+            Drawable placeholder = tryGetPlaceholderResource();
+            if (placeholder != null)
+                return placeholder.getIntrinsicHeight();
         }
-        Drawable placeholder = tryGetPlaceholderResource();
-        if (placeholder != null)
-            return placeholder.getIntrinsicHeight();
+        if (resizeHeight > 0)
+            return resizeHeight;
         return -1;
     }
 


### PR DESCRIPTION
I am not 100% of the logic that should apply to decide which is supposed to be displayed and so which size should be applied. But it works in my different resizing cases.

IMO that's not good to resize the drawables given by the user. But if it does then an option should be added to enable/disable this behavior.
