### PR TITLE
fix the ConscryptMiddleware disabling

### DIFF
--- a/ion/src/com/koushikdutta/ion/Ion.java
+++ b/ion/src/com/koushikdutta/ion/Ion.java
@@ -174,7 +174,7 @@ public class Ion {
 
         httpClient = new AsyncHttpClient(new AsyncServer("ion-" + name));
         httpClient.getSSLSocketMiddleware().setHostnameVerifier(new BrowserCompatHostnameVerifier());
-//        httpClient.insertMiddleware(conscryptMiddleware = new ConscryptMiddleware(context, httpClient.getSSLSocketMiddleware()));
+        httpClient.insertMiddleware(conscryptMiddleware = new ConscryptMiddleware(context, httpClient.getSSLSocketMiddleware()));
 
         File ionCacheDir = new File(context.getCacheDir(), name);
         try {

--- a/ion/src/com/koushikdutta/ion/conscrypt/ConscryptMiddleware.java
+++ b/ion/src/com/koushikdutta/ion/conscrypt/ConscryptMiddleware.java
@@ -68,6 +68,9 @@ public class ConscryptMiddleware extends SimpleMiddleware {
 
     @Override
     public Cancellable getSocket(GetSocketData data) {
+        if (!enabled) {
+            return null;
+        }
         // initialize here vs the constructor, or this will potentially block the ui thread.
         initialize();
         return super.getSocket(data);


### PR DESCRIPTION
The trick to disable conscrypt in https://github.com/koush/AndroidAsync/issues/210 didn't have any effect. Now it's bypassed correctly.
