### PR TITLE
Pass a cookie to the AsyncHttpRequest Factory

### DIFF
--- a/ion/src/com/koushikdutta/ion/Ion.java
+++ b/ion/src/com/koushikdutta/ion/Ion.java
@@ -578,7 +578,7 @@ public class Ion {
 
         AsyncHttpRequestFactory asyncHttpRequestFactory = new AsyncHttpRequestFactory() {
             @Override
-            public AsyncHttpRequest createAsyncHttpRequest(Uri uri, String method, RawHeaders headers) {
+            public AsyncHttpRequest createAsyncHttpRequest(Uri uri, String method, RawHeaders headers, Object cookie) {
                 AsyncHttpRequest request = new AsyncHttpRequest(uri, method, headers);
                 if (!TextUtils.isEmpty(userAgent))
                     request.getHeaders().setUserAgent(userAgent);

--- a/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
@@ -83,6 +83,7 @@ class IonRequestBuilder implements Builders.Any.B, Builders.Any.F, Builders.Any.
     Handler handler = Ion.mainHandler;
     String method = AsyncHttpGet.METHOD;
     String uri;
+    Object httpRequestCookie;
 
     public IonRequestBuilder(ContextReference contextReference, Ion ion) {
         String alive = contextReference.isAlive();
@@ -110,6 +111,11 @@ class IonRequestBuilder implements Builders.Any.B, Builders.Any.F, Builders.Any.
     public IonRequestBuilder load(String method, String url) {
         methodWasSet = true;
         return loadInternal(method, url);
+    }
+
+    @Override
+    public void setHttpRequestCookie(Object httpRequestCookie) {
+        this.httpRequestCookie = httpRequestCookie;
     }
 
     RawHeaders headers;
@@ -275,7 +281,7 @@ class IonRequestBuilder implements Builders.Any.B, Builders.Any.F, Builders.Any.
     }
 
     private AsyncHttpRequest prepareRequest(Uri uri, AsyncHttpRequestBody wrappedBody) {
-        AsyncHttpRequest request = ion.configure().getAsyncHttpRequestFactory().createAsyncHttpRequest(uri, method, headers);
+        AsyncHttpRequest request = ion.configure().getAsyncHttpRequestFactory().createAsyncHttpRequest(uri, method, headers, httpRequestCookie);
         request.setFollowRedirect(followRedirect);
         request.setBody(wrappedBody);
         request.setLogging(ion.logtag, ion.logLevel);

--- a/ion/src/com/koushikdutta/ion/builder/RequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/builder/RequestBuilder.java
@@ -276,4 +276,12 @@ public interface RequestBuilder<F, R extends RequestBuilder, M extends Multipart
      * @return
      */
     public Builders.Any.F setStreamBody(InputStream inputStream, int length);
+
+	/**
+	 * Set the cookie that will be used in {@link com.koushikdutta.ion.loader.AsyncHttpRequestFactory#createAsyncHttpRequest(
+	 * android.net.Uri, String, com.koushikdutta.async.http.libcore.RawHeaders, Object)
+	 * AsyncHttpRequestFactory.createAsyncHttpRequest()}
+	 * @param httpRequestCookie Cookie to create the {@link com.koushikdutta.async.http.AsyncHttpRequest AsyncHttpRequest}
+	 */
+	public void setHttpRequestCookie(Object httpRequestCookie);
 }

--- a/ion/src/com/koushikdutta/ion/loader/AsyncHttpRequestFactory.java
+++ b/ion/src/com/koushikdutta/ion/loader/AsyncHttpRequestFactory.java
@@ -9,5 +9,5 @@ import com.koushikdutta.async.http.libcore.RawHeaders;
  * Created by koush on 7/15/13.
  */
 public interface AsyncHttpRequestFactory {
-    public AsyncHttpRequest createAsyncHttpRequest(Uri uri, String method, RawHeaders headers);
+    public AsyncHttpRequest createAsyncHttpRequest(Uri uri, String method, RawHeaders headers, Object cookie);
 }


### PR DESCRIPTION
I need it to set some internal variables in my internal request. None of the uri+method+headers are unique enough to find the source Object that created the cookie.

Alternatively I can change the factory at every call (or create a `Ion` object for every call) but that's not thread safe (or uses a lot of memory for a simple thing)
