### PR TITLE
Crash fix when reading a Bitmap requires too much memory

### DIFF
--- a/ion/src/com/koushikdutta/ion/LoadBitmap.java
+++ b/ion/src/com/koushikdutta/ion/LoadBitmap.java
@@ -51,8 +51,10 @@ class LoadBitmap extends LoadBitmapEmitter implements FutureCallback<ByteBufferL
                     return;
                 }
 
-                ByteBuffer bb = result.getAll();
+                ByteBuffer bb = null;
                 try {
+                    bb = result.getAll();
+
                     Bitmap[] bitmaps;
                     int[] delays;
                     BitmapFactory.Options options = ion.bitmapCache.prepareBitmapOptions(bb.array(), bb.arrayOffset() + bb.position(), bb.remaining(), resizeWidth, resizeHeight);
@@ -100,7 +102,8 @@ class LoadBitmap extends LoadBitmapEmitter implements FutureCallback<ByteBufferL
                     report(e, null);
                 }
                 finally {
-                    ByteBufferList.reclaim(bb);
+                    if (bb != null)
+                        ByteBufferList.reclaim(bb);
                 }
             }
         });


### PR DESCRIPTION
Here is the stack trace I get (usually with animated GIF)

```
java.lang.OutOfMemoryError
    at java.nio.HeapByteBuffer.<init>(HeapByteBuffer.java:48)
    at java.nio.ReadWriteHeapByteBuffer.<init>(ReadWriteHeapByteBuffer.java:49)
    at java.nio.ByteBuffer.allocate(ByteBuffer.java:52)
    at com.koushikdutta.async.ByteBufferList.obtain(ByteBufferList.java:479)
    at com.koushikdutta.async.ByteBufferList.read(ByteBufferList.java:232)
    at com.koushikdutta.async.ByteBufferList.getAll(ByteBufferList.java:210)
    at com.koushikdutta.ion.LoadBitmap$1.run(LoadBitmap.java:54)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1076)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:569)
    at java.lang.Thread.run(Thread.java:856)
```
