### PR TITLE
Added the ability to layer a StateListDrawable over the bitmap.

### DIFF
--- a/ion/src/com/koushikdutta/ion/IonImageViewRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonImageViewRequestBuilder.java
@@ -3,11 +3,12 @@ package com.koushikdutta.ion;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
+import android.graphics.drawable.StateListDrawable;
 import android.os.Looper;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.widget.ImageView;
-
 import com.koushikdutta.async.future.Future;
 import com.koushikdutta.ion.bitmap.BitmapInfo;
 import com.koushikdutta.ion.builder.Builders;
@@ -28,6 +29,8 @@ public class IonImageViewRequestBuilder extends IonBitmapRequestBuilder implemen
     int placeholderResource;
     Drawable errorDrawable;
     int errorResource;
+    StateListDrawable stateDrawable;
+    int stateResource;
     Animation inAnimation;
     Animation loadAnimation;
     int loadAnimationResource;
@@ -84,14 +87,22 @@ public class IonImageViewRequestBuilder extends IonBitmapRequestBuilder implemen
 
     private IonDrawable setIonDrawable(ImageView imageView, BitmapInfo info, int loadedFrom) {
         IonDrawable ret = IonDrawable.getOrCreateIonDrawable(imageView)
-        .ion(ion)
-        .setBitmap(info, loadedFrom)
-        .setSize(resizeWidth, resizeHeight)
-        .setError(errorResource, errorDrawable)
-        .setPlaceholder(placeholderResource, placeholderDrawable)
-        .setInAnimation(inAnimation, inAnimationResource)
-        .setDisableFadeIn(disableFadeIn);
-        imageView.setImageDrawable(ret);
+                .ion(ion)
+                .setBitmap(info, loadedFrom)
+                .setSize(resizeWidth, resizeHeight)
+                .setError(errorResource, errorDrawable)
+                .setPlaceholder(placeholderResource, placeholderDrawable)
+                .setInAnimation(inAnimation, inAnimationResource)
+                .setDisableFadeIn(disableFadeIn);
+
+        if(stateDrawable == null && stateResource != 0) {
+            stateDrawable = (StateListDrawable) ion.getContext().getResources().getDrawable(stateResource);
+            LayerDrawable layerDrawable = new LayerDrawable(new Drawable[] {ret, stateDrawable});
+            imageView.setImageDrawable(layerDrawable);
+        }
+        else {
+            imageView.setImageDrawable(ret);
+        }
         return ret;
     }
 
@@ -220,6 +231,18 @@ public class IonImageViewRequestBuilder extends IonBitmapRequestBuilder implemen
     @Override
     public IonImageViewRequestBuilder error(int resourceId) {
         errorResource = resourceId;
+        return this;
+    }
+
+    @Override
+    public IonImageViewRequestBuilder stateList(StateListDrawable drawable) {
+        stateDrawable = drawable;
+        return this;
+    }
+
+    @Override
+    public IonImageViewRequestBuilder stateList(int resourceId) {
+        stateResource = resourceId;
         return this;
     }
 

--- a/ion/src/com/koushikdutta/ion/IonImageViewRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonImageViewRequestBuilder.java
@@ -97,6 +97,8 @@ public class IonImageViewRequestBuilder extends IonBitmapRequestBuilder implemen
 
         if(stateDrawable == null && stateResource != 0) {
             stateDrawable = (StateListDrawable) ion.getContext().getResources().getDrawable(stateResource);
+        }
+        if(stateDrawable != null) {
             LayerDrawable layerDrawable = new LayerDrawable(new Drawable[] {ret, stateDrawable});
             imageView.setImageDrawable(layerDrawable);
         }

--- a/ion/src/com/koushikdutta/ion/builder/ImageViewBuilder.java
+++ b/ion/src/com/koushikdutta/ion/builder/ImageViewBuilder.java
@@ -37,6 +37,20 @@ public interface ImageViewBuilder<I extends ImageViewBuilder<?>> {
     public I error(int resourceId);
 
     /**
+     * Layer a {@link android.graphics.drawable.StateListDrawable} over the bitmap
+     * @param drawable
+     * @return
+     */
+    public I stateList(StateListDrawable drawable);
+
+    /**
+     * Layer a {@link android.graphics.drawable.StateListDrawable} over the bitmap
+     * @param resourceId should reference a {@code <state-list-drawable>}
+     * @return
+     */
+    public I stateList(int resourceId);
+
+    /**
      * If an ImageView is loaded successfully from a remote source or file storage,
      * animate it in using the given Animation. The default animation is to fade
      * in.

--- a/ion/src/com/koushikdutta/ion/builder/ImageViewBuilder.java
+++ b/ion/src/com/koushikdutta/ion/builder/ImageViewBuilder.java
@@ -2,6 +2,7 @@ package com.koushikdutta.ion.builder;
 
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.StateListDrawable;
 import android.view.animation.Animation;
 
 /**


### PR DESCRIPTION
I was getting sick of using FrameLayouts with my ImageViews and layering a View with a StateListDrawable background on top of it. I did basic testing on this using a GridView. Seems to work fine (a little slower than usual if you provide a resource because the StateListDrawable needs to be parsed), but it seemed like I had to scroll an ImageView off the screen and then back on again to get it to display if it was loaded from the cache. Let me know if you want me to do more intensive testing.
