### PR TITLE
If GMS is installed we still need to make sure it will be used by AsyncSSLSocketMiddleware

### DIFF
--- a/ion/src/com/koushikdutta/ion/conscrypt/ConscryptMiddleware.java
+++ b/ion/src/com/koushikdutta/ion/conscrypt/ConscryptMiddleware.java
@@ -41,8 +41,10 @@ public class ConscryptMiddleware extends SimpleMiddleware {
                 initialized = true;
 
                 // GMS Conscrypt is already initialized, from outside ion. Leave it alone.
-                if (Security.getProvider(GMS_PROVIDER) != null)
+                if (Security.getProvider(GMS_PROVIDER) != null) {
+                    success = true;
                     return;
+                }
 
                 SSLContext originalDefaultContext = SSLContext.getDefault();
                 SSLSocketFactory originalDefaultSSLSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();


### PR DESCRIPTION
It's not because Conscrypt is installed that it's the default one, so make sure we use Conscrypt in AsyncSSLSocketMiddleware

(patch against branch 1.x)
