### PR TITLE
adapt to changes in AndroidAsync performed to fix issue 461

### DIFF
--- a/ion/src/com/koushikdutta/ion/Ion.java
+++ b/ion/src/com/koushikdutta/ion/Ion.java
@@ -148,6 +148,10 @@ public class Ion {
     Context context;
     IonImageViewRequestBuilder bitmapBuilder = new IonImageViewRequestBuilder(this);
 
+    public FileCache getStoreCache() {
+        return storeCache;
+    }
+
     private Ion(Context context, String name) {
         this.context = context = context.getApplicationContext();
         this.name = name;

--- a/ion/src/com/koushikdutta/ion/IonBitmapRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonBitmapRequestBuilder.java
@@ -32,7 +32,7 @@ abstract class IonBitmapRequestBuilder implements BitmapFutureBuilder, Builders.
     };
 
     IonRequestBuilder builder;
-    Ion ion;
+    static Ion ion;
     ArrayList<Transform> transforms;
     ScaleMode scaleMode;
     int resizeWidth;
@@ -114,7 +114,7 @@ abstract class IonBitmapRequestBuilder implements BitmapFutureBuilder, Builders.
             decodeKey += ":noAnimate";
         if (deepZoom)
             decodeKey += ":deepZoom";
-        return FileCache.toKeyString(decodeKey);
+        return ion.getCache().toKeyString(decodeKey);
     }
 
     public void addDefaultTransform() {
@@ -141,7 +141,7 @@ abstract class IonBitmapRequestBuilder implements BitmapFutureBuilder, Builders.
             for (Transform transform : transforms) {
                 bitmapKey += transform.key();
             }
-            bitmapKey = FileCache.toKeyString(bitmapKey);
+            bitmapKey = ion.getCache().toKeyString(bitmapKey);
         }
 
         return bitmapKey;

--- a/ion/src/com/koushikdutta/ion/IonDrawable.java
+++ b/ion/src/com/koushikdutta/ion/IonDrawable.java
@@ -675,7 +675,7 @@ class IonDrawable extends LayerDrawable {
 
                 // find, render/fetch
 //                    System.out.println("rendering: " + texRect + " for: " + bounds);
-                String tileKey = FileCache.toKeyString(info.key, ",", level, ",", x, ",", y);
+                String tileKey = ion.getCache().toKeyString(info.key, ",", level, ",", x, ",", y);
                 BitmapInfo tile = ion.bitmapCache.get(tileKey);
                 if (tile != null && tile.bitmap != null) {
                     // render it
@@ -704,7 +704,7 @@ class IonDrawable extends LayerDrawable {
                 int parentY = y >> 1;
 
                 while (parentLevel >= 0) {
-                    tileKey = FileCache.toKeyString(info.key, ",", parentLevel, ",", parentX, ",", parentY);
+                    tileKey = ion.getCache().toKeyString(info.key, ",", parentLevel, ",", parentX, ",", parentY);
                     tile = ion.bitmapCache.get(tileKey);
                     if (tile != null && tile.bitmap != null)
                         break;


### PR DESCRIPTION
I performed changes to adapt this library to work on top of AndroidAsync modified by me in commit https://github.com/koush/AndroidAsync/commit/98a9d50ec4e466ee8d84be47e0a7bab6434e7d0f.
It's rather quick fix, using not the best patterns, to get the stuff done, but it works flawlessly. Probably you will want to adjust it to meet your standards.
I used FileCache named storeCache in Ion to resolve method calls that were static, and I changed Ion reference to static in IonBitmapRequestBuilder, assuming that Ion is anywany called in static way, to prevent changing other methods to non-static.