### PR TITLE
Stop progress bar from updating if the request is cancelled or done

### DIFF
--- a/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
@@ -510,6 +510,8 @@ class IonRequestBuilder implements Builders.Any.B, Builders.Any.F, Builders.Any.
                         AsyncServer.post(Ion.mainHandler, new Runnable() {
                             @Override
                             public void run() {
+                                if (isCancelled() || isDone())
+                                    return;
                                 if (progressBar != null) {
                                     ProgressBar bar = progressBar.get();
                                     if (bar != null)


### PR DESCRIPTION
I noticed the progress bar jumping around when scrolling through a listview with imageviews in each cell.  Even though the previous futures had been cancelled, the progress was still being updated on the progress bars.

This change handles progress updates in a very similar manner as the progressHandler on line 537 of the same file.  
