### PR TITLE
Add consumerProguardFile

### DIFF
--- a/ion/build.gradle
+++ b/ion/build.gradle
@@ -35,6 +35,7 @@ android {
     defaultConfig {
         targetSdkVersion 23
         minSdkVersion 9
+        consumerProguardFiles 'proguard-project.txt'
     }
 
     compileSdkVersion 23

--- a/ion/proguard-project.txt
+++ b/ion/proguard-project.txt
@@ -18,3 +18,4 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+-keep class com.google.android.gms.security.ProviderInstaller { *; }


### PR DESCRIPTION
Prevent obfuscation of GMS ProviderInstaller 
https://github.com/koush/ion/blob/7ddf485b066b59a1b10e13a022095734cc14e6e1/ion/src/com/koushikdutta/ion/conscrypt/ConscryptMiddleware.java#L57

Trying to alleviate Issue #782 , #647 
But without GMS, Ion would still not work on pre-Lollipop devices with SSL enabled