### PR TITLE
Added possibility to change the CookieMiddleware

### DIFF
--- a/ion/src/com/koushikdutta/ion/Ion.java
+++ b/ion/src/com/koushikdutta/ion/Ion.java
@@ -185,7 +185,7 @@ public class Ion {
 
         // TODO: Support pre GB?
         if (Build.VERSION.SDK_INT >= 9)
-            addCookieMiddleware();
+            setCookieMiddleware(new CookieMiddleware(this));
 
         httpClient.getSocketMiddleware().setConnectAllAddresses(true);
         httpClient.getSSLSocketMiddleware().setConnectAllAddresses(true);
@@ -413,8 +413,11 @@ public class Ion {
     // maintain a list of futures that are in being processed, allow for bulk cancellation
     WeakHashMap<Object, FutureSet> inFlight = new WeakHashMap<Object, FutureSet>();
 
-    private void addCookieMiddleware() {
-        httpClient.insertMiddleware(cookieMiddleware = new CookieMiddleware(this));
+    public void setCookieMiddleware(CookieMiddleware middleware) {
+        if (cookieMiddleware != null) {
+            httpClient.getMiddleware().remove(cookieMiddleware);
+        }
+        httpClient.insertMiddleware(cookieMiddleware = middleware);
     }
 
     /**


### PR DESCRIPTION
Referring to the issue https://github.com/koush/ion/issues/845, I added the possibility to change the current `CookieMiddleware` with the method written below in the `Ion` class:

```java
public void setCookieMiddleware(CookieMiddleware middleware)
```
Example of usage:
```java
Ion ion = Ion.getDefault(context);
ion.setCookieMiddleware(new CustomCookieMiddleware(this));
```
