### PR TITLE
Added possibility to set a custom CookieMiddleware and CookieManager

### DIFF
--- a/ion/src/com/koushikdutta/ion/Ion.java
+++ b/ion/src/com/koushikdutta/ion/Ion.java
@@ -185,7 +185,7 @@ public class Ion {
 
         // TODO: Support pre GB?
         if (Build.VERSION.SDK_INT >= 9)
-            addCookieMiddleware();
+            setCookieMiddleware(new CookieMiddleware(this));
 
         httpClient.getSocketMiddleware().setConnectAllAddresses(true);
         httpClient.getSSLSocketMiddleware().setConnectAllAddresses(true);
@@ -413,8 +413,11 @@ public class Ion {
     // maintain a list of futures that are in being processed, allow for bulk cancellation
     WeakHashMap<Object, FutureSet> inFlight = new WeakHashMap<Object, FutureSet>();
 
-    private void addCookieMiddleware() {
-        httpClient.insertMiddleware(cookieMiddleware = new CookieMiddleware(this));
+    public void setCookieMiddleware(CookieMiddleware middleware) {
+        if (cookieMiddleware != null) {
+            httpClient.getMiddleware().remove(cookieMiddleware);
+        }
+        httpClient.insertMiddleware(cookieMiddleware = middleware);
     }
 
     /**

--- a/ion/src/com/koushikdutta/ion/cookie/CookieMiddleware.java
+++ b/ion/src/com/koushikdutta/ion/cookie/CookieMiddleware.java
@@ -38,13 +38,17 @@ public class CookieMiddleware extends SimpleMiddleware {
         return manager;
     }
 
+    protected CookieManager initializeCookieManager(Ion ion) {
+        return new CookieManager(null, null);
+    }
+
     Ion ion;
     public CookieMiddleware(Ion ion) {
         this.ion = ion;
     }
 
     public void reinit() {
-        manager = new CookieManager(null, null);
+        manager = initializeCookieManager(ion);
         preferences = ion.getContext().getSharedPreferences(ion.getName() + "-cookies", Context.MODE_PRIVATE);
 
         Map<String, ?> allPrefs = preferences.getAll();
@@ -89,8 +93,8 @@ public class CookieMiddleware extends SimpleMiddleware {
         maybeInit();
         try {
             Map<String, List<String>> cookies = manager.get(
-                URI.create(
-                    data.request.getUri().toString()),
+                    URI.create(
+                            data.request.getUri().toString()),
                     data.request.getHeaders().getMultiMap());
             addCookies(cookies, data.request.getHeaders());
         }


### PR DESCRIPTION
Referring to the issue #845, I added the possibility to change the current `CookieMiddleware`and to set a custom `CookieManager` (e.g. a persistent storage `CookieManager` that holds the cookies across the sessions)