### PR TITLE
Adding formatted load and setMethod

### DIFF
--- a/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
@@ -122,6 +122,11 @@ class IonRequestBuilder implements Builders.Any.B, Builders.Any.F, Builders.Any.
     }
 
     @Override
+    public IonRequestBuilder load(String format, String... args) {
+        return load(String.format(format, args));
+    }
+
+    @Override
     public IonRequestBuilder load(AsyncHttpRequest request) {
         headers = new Headers(request.getHeaders().getMultiMap());
         setBody(request.getBody());

--- a/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/IonRequestBuilder.java
@@ -115,6 +115,13 @@ class IonRequestBuilder implements Builders.Any.B, Builders.Any.F, Builders.Any.
     }
 
     @Override
+    public R setMethod(String method) {
+        methodWasSet = true;
+        this.method = method;
+        return this;
+    }
+
+    @Override
     public IonRequestBuilder load(AsyncHttpRequest request) {
         headers = new Headers(request.getHeaders().getMultiMap());
         setBody(request.getBody());

--- a/ion/src/com/koushikdutta/ion/builder/LoadBuilder.java
+++ b/ion/src/com/koushikdutta/ion/builder/LoadBuilder.java
@@ -16,6 +16,13 @@ public interface LoadBuilder<B> {
     public B load(String uri);
 
     /**
+     * @param format Format string in C's printf style.
+     * @param args Arguments referenced by the format specifiers in the format string.
+     * @return
+     */
+    public B load(String format, String... args);
+
+    /**
      * Load an url using the given an HTTP method such as GET or POST.
      * @param method HTTP method such as GET or POST.
      * @param url Url to load.

--- a/ion/src/com/koushikdutta/ion/builder/RequestBuilder.java
+++ b/ion/src/com/koushikdutta/ion/builder/RequestBuilder.java
@@ -108,6 +108,13 @@ public interface RequestBuilder<F, R extends RequestBuilder, M extends Multipart
     public R setHandler(Handler handler);
 
     /**
+     * Set the HTTP method explicitly
+     * @param method HTTP method of the request
+     * @return
+     */
+    public R setMethod(String method);
+
+    /**
      * Set a HTTP header
      * @param name Header name
      * @param value Header value

--- a/ion/test/src/com/koushikdutta/ion/test/Issues.java
+++ b/ion/test/src/com/koushikdutta/ion/test/Issues.java
@@ -397,5 +397,6 @@ public class Issues extends AndroidTestCase {
                 "https://raw.githubusercontent.com/%s/AndroidAsync/master/AndroidAsync/test/assets/test.json",
                 username)
                 .asString().get();
+        Assert.asserEquals(noFormatting, withFormatting);
     }
 }

--- a/ion/test/src/com/koushikdutta/ion/test/Issues.java
+++ b/ion/test/src/com/koushikdutta/ion/test/Issues.java
@@ -388,4 +388,14 @@ public class Issues extends AndroidTestCase {
                 + "} should be equal to {Pixel(35,200,5): " + Integer.toHexString(frame5Pixel) + "}";
         Assert.assertEquals(assertionMessage, frame4Pixel, frame5Pixel);
     }
+
+    public void testIssue365() throw Exception {
+        String noFormatting = Ion.with(getContext()).load("https://raw.githubusercontent.com/koush/AndroidAsync/master/AndroidAsync/test/assets/test.json")
+                .asString().get();
+        String username = "koush";
+        String withFormatting = Ion.with(getContext()).load(
+                "https://raw.githubusercontent.com/%s/AndroidAsync/master/AndroidAsync/test/assets/test.json",
+                username)
+                .asString().get();
+    }
 }


### PR DESCRIPTION
Closes #365 by adding the requested `load(String format, String... args)`
also adds `setMethod(String method)` which sets request method explicitly similar to `load(String method, String url)`. with this addition `load(String method, String url)` is no longer needed but should remain for compatibility.
also added a test for `load(String format, String... args)` which wasn't probably needed!